### PR TITLE
Use atob instead of window.atob to support non-window environments

### DIFF
--- a/src/MultiPartParser.js
+++ b/src/MultiPartParser.js
@@ -228,7 +228,7 @@ export class MultiPartParser {
             const decoder = new TextDecoder();
             raw = decoder.decode(raw);
         }
-        const binary_string = window.atob(raw);
+        const binary_string = atob(raw);
         const len = binary_string.length;
         const bytes = new Uint8Array(len);
         for (let i = 0; i < len; i++) {


### PR DESCRIPTION
Replacing `window.atob` with `atob` gives out-of-the-box Deno 2.0 support without requiring any shims (see https://github.com/denoland/deno/issues/13367 for context). In browsers it will continue to run identically, as `atob === window.atob`.